### PR TITLE
Fixes #7.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,7 @@ jobs:
           cache: pnpm
       - run: pnpm i -r
       - run: npm run build
-      - run: npm pkg delete devDependencies
-      - name: Rebuild pnpm-lock.yaml
-        run: pnpm i --no-frozen-lockfile
+      - run: npm pkg delete devDependencies scripts
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # hostlocal
 
-Serve files from a directory.
+Serve files from a directory over HTTP/1.1 and HTTP/2, with live reload
+notifications over a websocket.  It will automatically create self-signed
+certificates.
+
+This server is quite opinionated about its defaults to make setup as easy
+as possible... if you have a problem shaped like mine.
 
 ## Run
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,19 @@
 {
   "name": "hostlocal",
   "version": "0.2.0",
-  "decription": "",
+  "decription": "Serve files from a directory over HTTP/1.1 and HTTP/2, with live reload notifications over a websocket.",
   "main": "lib/index.js",
   "type": "module",
-  "keywords": [],
+  "keywords": [
+    "http",
+    "https",
+    "http2",
+    "server",
+    "config file",
+    "websocket",
+    "live-reload",
+    "localhost"
+  ],
   "author": "Joe Hildebrand <joe-github@cursive.net>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Turn on HTTP/2, with fallbacks to HTTP/1.1 so that
the ws websocket library will still work.
