### PR TITLE
Fixes #12

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@cto.af/eslint-config": "5.0.0",
-    "@playwright/test": "1.48.0",
+    "@playwright/test": "1.48.1",
     "@types/jsrsasign": "10.5.14",
     "@types/markdown-it": "14.1.2",
     "@types/mime-types": "2.1.4",
@@ -63,10 +63,11 @@
     "c8": "10.1.2",
     "eslint-plugin-jsdoc": "50.4.1",
     "eslint-plugin-markdown": "5.1.0",
+    "node-mocks-http": "1.16.1",
     "package-extract": "2.3.0",
     "rimraf": "6.0.1",
     "snappy-snaps": "1.1.0",
-    "typedoc": "0.26.9",
+    "typedoc": "0.26.10",
     "typescript": "5.6.3",
     "typescript-eslint": "8.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0(eslint@9.12.0)(typescript@5.6.3)
       '@playwright/test':
-        specifier: 1.48.0
-        version: 1.48.0
+        specifier: 1.48.1
+        version: 1.48.1
       '@types/jsrsasign':
         specifier: 10.5.14
         version: 10.5.14
@@ -63,6 +63,9 @@ importers:
       eslint-plugin-markdown:
         specifier: 5.1.0
         version: 5.1.0(eslint@9.12.0)
+      node-mocks-http:
+        specifier: 1.16.1
+        version: 1.16.1(@types/node@22.7.5)
       package-extract:
         specifier: 2.3.0
         version: 2.3.0
@@ -73,8 +76,8 @@ importers:
         specifier: 1.1.0
         version: 1.1.0
       typedoc:
-        specifier: 0.26.9
-        version: 0.26.9(typescript@5.6.3)
+        specifier: 0.26.10
+        version: 0.26.10(typescript@5.6.3)
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -191,8 +194,8 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.48.0':
-    resolution: {integrity: sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==}
+  '@playwright/test@1.48.1':
+    resolution: {integrity: sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -349,6 +352,10 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -479,6 +486,10 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -509,6 +520,10 @@ packages:
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
+
+  depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -655,6 +670,10 @@ packages:
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -858,9 +877,20 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
 
   micromark-util-character@2.1.0:
     resolution: {integrity: sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==}
@@ -892,6 +922,11 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   minimatch@10.0.1:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
     engines: {node: 20 || >=22}
@@ -913,9 +948,25 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
   node-gyp-build@4.8.2:
     resolution: {integrity: sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==}
     hasBin: true
+
+  node-mocks-http@1.16.1:
+    resolution: {integrity: sha512-Q2m5bmIE1KFeeKI6OsSn+c4XDara5NWnUJgzqnIkhiCNukYX+fqu0ADSeKOlpWtbCwgRnJ69F+7RUiQltzTKXA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@types/express': ^4.17.21 || ^5.0.0
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/express':
+        optional: true
+      '@types/node':
+        optional: true
 
   oniguruma-to-js@0.4.3:
     resolution: {integrity: sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==}
@@ -955,6 +1006,10 @@ packages:
     resolution: {integrity: sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==}
     engines: {node: '>= 18'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -979,13 +1034,13 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
-  playwright-core@1.48.0:
-    resolution: {integrity: sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==}
+  playwright-core@1.48.1:
+    resolution: {integrity: sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.48.0:
-    resolution: {integrity: sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==}
+  playwright@1.48.1:
+    resolution: {integrity: sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1009,6 +1064,10 @@ packages:
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
 
   readdirp@4.0.2:
     resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
@@ -1151,8 +1210,12 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typedoc@0.26.9:
-    resolution: {integrity: sha512-Rc7QpWL7EtmrT8yxV0GmhOR6xHgFnnhphbD9Suti3fz3um7ZOrou6q/g9d6+zC5PssTLZmjaW4Upmzv8T1rCcQ==}
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  typedoc@0.26.10:
+    resolution: {integrity: sha512-xLmVKJ8S21t+JeuQLNueebEuTVphx6IrP06CdV7+0WVflUSW3SPmR+h1fnWVdAR/FQePEgsSWCUHXqKKjzuUAw==}
     engines: {node: '>= 18'}
     hasBin: true
     peerDependencies:
@@ -1377,9 +1440,9 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@playwright/test@1.48.0':
+  '@playwright/test@1.48.1':
     dependencies:
-      playwright: 1.48.0
+      playwright: 1.48.1
 
   '@shikijs/core@1.22.0':
     dependencies:
@@ -1584,6 +1647,11 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   acorn-jsx@5.3.2(acorn@8.12.1):
     dependencies:
       acorn: 8.12.1
@@ -1695,6 +1763,10 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.3:
@@ -1717,6 +1789,8 @@ snapshots:
       default-browser-id: 5.0.0
 
   define-lazy-prop@3.0.0: {}
+
+  depd@1.1.2: {}
 
   dequal@2.0.3: {}
 
@@ -1900,6 +1974,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
+
+  fresh@0.5.2: {}
 
   fsevents@2.3.2:
     optional: true
@@ -2111,7 +2187,13 @@ snapshots:
 
   mdurl@2.0.0: {}
 
+  media-typer@0.3.0: {}
+
+  merge-descriptors@1.0.3: {}
+
   merge2@1.4.1: {}
+
+  methods@1.1.2: {}
 
   micromark-util-character@2.1.0:
     dependencies:
@@ -2148,6 +2230,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mime@1.6.0: {}
+
   minimatch@10.0.1:
     dependencies:
       brace-expansion: 2.0.1
@@ -2166,7 +2250,24 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@0.6.3: {}
+
   node-gyp-build@4.8.2: {}
+
+  node-mocks-http@1.16.1(@types/node@22.7.5):
+    dependencies:
+      accepts: 1.3.8
+      content-disposition: 0.5.4
+      depd: 1.1.2
+      fresh: 0.5.2
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      mime: 1.6.0
+      parseurl: 1.3.3
+      range-parser: 1.2.1
+      type-is: 1.6.18
+    optionalDependencies:
+      '@types/node': 22.7.5
 
   oniguruma-to-js@0.4.3:
     dependencies:
@@ -2221,6 +2322,8 @@ snapshots:
       es-module-lexer: 1.5.4
       slashes: 3.0.12
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -2239,11 +2342,11 @@ snapshots:
 
   picomatch@4.0.2: {}
 
-  playwright-core@1.48.0: {}
+  playwright-core@1.48.1: {}
 
-  playwright@1.48.0:
+  playwright@1.48.1:
     dependencies:
-      playwright-core: 1.48.0
+      playwright-core: 1.48.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -2260,6 +2363,8 @@ snapshots:
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  range-parser@1.2.1: {}
 
   readdirp@4.0.2: {}
 
@@ -2390,7 +2495,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typedoc@0.26.9(typescript@5.6.3):
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
+  typedoc@0.26.10(typescript@5.6.3):
     dependencies:
       lunr: 2.3.9
       markdown-it: 14.1.0

--- a/src/opts.ts
+++ b/src/opts.ts
@@ -1,7 +1,7 @@
 import {type CertOptions, DEFAULT_CERT_OPTIONS} from './cert.js';
 import path from 'node:path';
 
-export type ListenCallback = (url: string) => void;
+export type ListenCallback = (url: URL) => void;
 export type EmptyCallback = () => void;
 
 export interface HostOptions extends CertOptions {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,0 +1,107 @@
+import type {Http2ServerRequest, Http2ServerResponse, OutgoingHttpHeaders} from 'node:http2';
+import {addClientScript, markdownToHTML} from './html.js';
+import type {FSWatcher} from 'chokidar';
+import type {RequiredHostOptions} from './opts.js';
+import fs from 'node:fs/promises';
+import mt from 'mime-types';
+import path from 'node:path';
+
+export interface ServerState {
+  base: string;
+  baseURL: URL;
+  watcher: FSWatcher;
+  headers: OutgoingHttpHeaders;
+}
+
+async function findExistingFile(
+  dir: string,
+  possible: string[]
+): Promise<string> {
+  for (const p of possible) {
+    try {
+      const file = path.join(dir, p);
+      const stat = await fs.stat(file);
+      if (stat.isFile()) {
+        return file;
+      }
+    } catch (_ignored) {
+      // Ignored
+    }
+  }
+  const er = new Error('No index file found') as NodeJS.ErrnoException;
+  er.code = 'ENOENT';
+  throw er;
+}
+
+/**
+ * Actually serve the file, if found.
+ *
+ * @param opts Options.
+ * @param state Server state.
+ * @param req Request.
+ * @param res Response.
+ * @returns Status code sent, for logging.
+ */
+export async function serve(
+  opts: RequiredHostOptions,
+  state: ServerState,
+  req: Http2ServerRequest,
+  res: Http2ServerResponse
+): Promise<number> {
+  function error(code: number, text: string): number {
+    res.writeHead(code, state.headers).end(`${text}\n`);
+    return code;
+  }
+
+  let buf = null;
+  let file = null;
+  let pathname = null;
+  try {
+    if (req.method !== 'GET') {
+      return error(405, `Method ${req.method} not supported`);
+    }
+
+    const url = new URL(req.url, state.baseURL);
+    ({pathname} = url);
+    file = await fs.realpath(path.resolve(path.join(state.base, pathname)));
+    if (!file.startsWith(state.base)) {
+      return error(403, 'Invalid path');
+    }
+    const stat = await fs.stat(file);
+
+    if (stat.isDirectory()) {
+      file = await findExistingFile(file, opts.index);
+    }
+    buf = await fs.readFile(file);
+    state.watcher.add(file);
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    if (err?.code === 'ENOENT') {
+      return error(404, `No such file: "${pathname}"`);
+    }
+    return error(500, (e as Error).message);
+  }
+  let mime = mt.lookup(file) || 'text/plain';
+  switch (mime) {
+    case 'text/html':
+      buf = addClientScript(buf);
+      break;
+    case 'text/markdown': {
+      if (opts.rawMarkdown) {
+        break;
+      }
+
+      buf = markdownToHTML(buf, pathname);
+      mime = 'text/html';
+      break;
+    }
+    default:
+      break;
+  }
+  res.writeHead(200, {
+    ...state.headers,
+    'Content-Length': buf.length,
+    'Content-Type': mime,
+  }).end(buf);
+  return 200;
+}

--- a/test/fixtures/foo.unknown-type
+++ b/test/fixtures/foo.unknown-type
@@ -1,0 +1,1 @@
+".unknown-type" is not currently in the mime-types package

--- a/test/serve.test.js
+++ b/test/serve.test.js
@@ -1,0 +1,49 @@
+import {name, version} from '../lib/version.js';
+import assert from 'node:assert';
+import chokidar from 'chokidar';
+import fs from 'node:fs/promises';
+import httpMocks from 'node-mocks-http';
+import {normalizeOptions} from '../lib/opts.js';
+import {serve} from '../lib/serve.js';
+import test from 'node:test';
+
+test('serve', async() => {
+  const opts = await normalizeOptions({
+    config: 'DOES_NOT_EXIST',
+    rawMarkdown: true,
+  });
+  const state = {
+    headers: {
+      Server: `${name}/${version}`,
+    },
+    base: await fs.realpath(new URL('../', import.meta.url)),
+    baseURL: new URL(`https://localhost:${opts.port}/`),
+    watcher: chokidar.watch([], {
+      atomic: true,
+      ignoreInitial: true,
+      persistent: false,
+    }),
+  };
+
+  function reqRes(url, method = 'GET') {
+    const req = httpMocks.createRequest({method, url});
+    const res = httpMocks.createResponse({req});
+    return [req, res];
+  }
+
+  let code = await serve(opts, state, ...reqRes('////'));
+  assert.equal(code, 500);
+
+  code = await serve(opts, state, ...reqRes('/', 'POST'));
+  assert.equal(code, 405);
+
+  code = await serve(opts, state, ...reqRes('/'));
+  assert.equal(code, 200);
+
+  code = await serve(opts, state, ...reqRes('/package.json'));
+  assert.equal(code, 200);
+
+  code = await serve(opts, state, ...reqRes('/test/fixtures/foo.unknown-type'));
+  assert.equal(code, 200);
+});
+


### PR DESCRIPTION
Parse the incoming URL, keeping just the pathname.

Continued to refactor index.ts, pulled out core
serving logic into serve.ts, which allows testing
a few more of the edge cases.
