### PR TITLE
Move to processing files in streams.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/jsrsasign": "10.5.14",
     "@types/markdown-it": "14.1.2",
     "@types/mime-types": "2.1.4",
-    "@types/node": "22.7.5",
+    "@types/node": "22.7.6",
     "@types/ws": "8.5.12",
     "c8": "10.1.2",
     "eslint-plugin-jsdoc": "50.4.1",
@@ -71,7 +71,7 @@
     "typescript": "5.6.3",
     "typescript-eslint": "8.9.0"
   },
-  "packageManager": "pnpm@9.12.1",
+  "packageManager": "pnpm@9.12.2",
   "engines": {
     "node": ">=22"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: 2.1.4
         version: 2.1.4
       '@types/node':
-        specifier: 22.7.5
-        version: 22.7.5
+        specifier: 22.7.6
+        version: 22.7.6
       '@types/ws':
         specifier: 8.5.12
         version: 8.5.12
@@ -65,7 +65,7 @@ importers:
         version: 5.1.0(eslint@9.12.0)
       node-mocks-http:
         specifier: 1.16.1
-        version: 1.16.1(@types/node@22.7.5)
+        version: 1.16.1(@types/node@22.7.6)
       package-extract:
         specifier: 2.3.0
         version: 2.3.0
@@ -253,8 +253,8 @@ packages:
   '@types/mime-types@2.1.4':
     resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
 
-  '@types/node@22.7.5':
-    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+  '@types/node@22.7.6':
+    resolution: {integrity: sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1514,7 +1514,7 @@ snapshots:
 
   '@types/mime-types@2.1.4': {}
 
-  '@types/node@22.7.5':
+  '@types/node@22.7.6':
     dependencies:
       undici-types: 6.19.8
 
@@ -1524,7 +1524,7 @@ snapshots:
 
   '@types/ws@8.5.12':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@typescript-eslint/eslint-plugin@8.9.0(@typescript-eslint/parser@8.9.0(eslint@9.12.0)(typescript@5.6.3))(eslint@9.12.0)(typescript@5.6.3)':
     dependencies:
@@ -2254,7 +2254,7 @@ snapshots:
 
   node-gyp-build@4.8.2: {}
 
-  node-mocks-http@1.16.1(@types/node@22.7.5):
+  node-mocks-http@1.16.1(@types/node@22.7.6):
     dependencies:
       accepts: 1.3.8
       content-disposition: 0.5.4
@@ -2267,7 +2267,7 @@ snapshots:
       range-parser: 1.2.1
       type-is: 1.6.18
     optionalDependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   oniguruma-to-js@0.4.3:
     dependencies:

--- a/src/html.ts
+++ b/src/html.ts
@@ -1,6 +1,28 @@
+import {Readable, Transform, type TransformCallback} from 'node:stream';
 import {Buffer} from 'node:buffer';
 import fs from 'node:fs/promises';
 import markdownit from 'markdown-it';
+
+export interface FileInfo {
+
+  /** Fully-qualified path to file, resolved. */
+  file: string;
+
+  /** Request URL path portion. */
+  pathname: string;
+
+  /**
+   * Currently-know content-length for the file.
+   * Undefined for chunked transfer encoding.
+   */
+  size?: number;
+
+  /**
+   * Read the file from a stream.  May be replaced multiple times with
+   * transforms.
+   */
+  stream?: Readable;
+}
 
 const md = markdownit({
   html: true,
@@ -8,6 +30,7 @@ const md = markdownit({
   typographer: true,
 });
 
+// Pre-cache client JS
 const clientSrc = await fs.readFile(
   new URL('./client.js', import.meta.url),
   'utf8'
@@ -20,30 +43,116 @@ ${clientSrc}
 const clientScriptBuffer = Buffer.from(clientScriptString);
 
 /**
- * Add the client script for auto-refresh to the end of the HTML contents.
- *
- * @param buf Original HTML.
- * @returns Modified HTML.
+ * Add the client JS onto the end of an HTML stream.
+ * Pass the original stream through until we get to the end, then tack on
+ * the script.
  */
-export function addClientScript(buf: Buffer): Buffer {
-  return Buffer.concat([buf, clientScriptBuffer]);
+export class AddClient extends Transform {
+  public constructor(info: FileInfo) {
+    super();
+    if (info.size) {
+      info.size += clientScriptBuffer.length;
+    }
+  }
+
+  public _transform(
+    chunk: unknown,
+    encoding: BufferEncoding,
+    callback: TransformCallback
+  ): void {
+    this.push(chunk, encoding);
+    callback();
+  }
+
+  public _flush(callback: TransformCallback): void {
+    this.push(clientScriptBuffer);
+    callback();
+  }
 }
 
 /**
- * Render Markdown to HTML.
- *
- * @param buf Markdown.
- * @param url This documnent's URL.
- * @returns HTML in a buffer.
+ * Convert markdown to HTML in an overly-elaborate fashion.
  */
-export function markdownToHTML(buf: Buffer, url: string): Buffer {
-  const mkd = buf.toString();
-  const html = `\
+export class MarkdownToHtml extends Transform {
+  static #encodedStringChunks: Buffer[] = [];
+  #bufs: Buffer[] = [];
+  #info: FileInfo;
+
+  static {
+    // Pre-cache all of the buffer versions of the strings, and figure
+    // out the number of bytes this is going to add.
+    const t = new MarkdownToHtml({
+      file: '',
+      pathname: '',
+      size: 0,
+    });
+    Readable.from([]).pipe(t);
+  }
+
+  public constructor(info: FileInfo) {
+    super();
+    this.#info = info;
+    // Can't pre-compute the size, since that is only known after conversion
+    info.size = undefined;
+  }
+
+  /**
+   * Template string tag function.  Alternate string and value.  Special
+   * attention on the ends, were string might be '' or value might be
+   * undefined.
+   *
+   * @param strings Static portions of the template.
+   * @param values Results of blocks inserted into the template.
+   * @yields Buffers to go into the stream.
+   * @example
+   * ```js
+   * for (const buf of MarkdownToHtml.#encode`foo${bar}baz`) {
+   *   this.push(buf); // Hopefully called exactly 3 times
+   * }
+   * ```
+   */
+  static *#encode(
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): Generator<Buffer, void, undefined> {
+    for (let i = 0; i < strings.length; i++) {
+      if (strings[i]) {
+        let buf = MarkdownToHtml.#encodedStringChunks[i];
+        if (!buf) {
+          buf = Buffer.from(strings[i]);
+          MarkdownToHtml.#encodedStringChunks[i] = buf;
+        }
+        yield buf;
+      }
+      if (values[i] != null) {
+        const buf = Buffer.isBuffer(values[i]) ?
+          values[i] as Buffer :
+          Buffer.from(String(values[i]));
+        yield buf;
+      }
+    }
+  }
+
+  public _transform(
+    chunk: unknown,
+    _encoding: BufferEncoding,
+    callback: TransformCallback
+  ): void {
+    // Store all of the chunks until we're done.
+    this.#bufs.push(chunk as Buffer);
+    callback();
+  }
+
+  public _flush(callback: TransformCallback): void {
+    const mkd = Buffer.concat(this.#bufs).toString();
+    const html = Buffer.from(md.render(mkd));
+
+    for (const buf of MarkdownToHtml.#encode`\
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>${url}</title>
+  <title>${this.#info.pathname}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.7.0/github-markdown-dark.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
@@ -66,11 +175,14 @@ export function markdownToHTML(buf: Buffer, url: string): Buffer {
   </style>
 </head>
 <body class="markdown-body">
-${md.render(mkd)}
+${html}
 </body>
 </html>
 <script>hljs.highlightAll();</script>
-${clientScriptString}
-`;
-  return Buffer.from(html);
+`) {
+      this.push(buf);
+    }
+
+    callback();
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,9 +95,6 @@ export async function hostLocal(
             process.exit(0);
           }
           break;
-        default:
-          // Ignored
-          break;
       }
     });
   });


### PR DESCRIPTION
This works for everything but markdown files,
which need to be gathered into memore before being
processed into HTML; at that point the results can
move back into streaming mode, with each of the
pieces of the generated HTML being a separate
chunk in chunked transfer encoding.
