### PR TITLE
fix 29

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,7 @@ import http2 from 'node:http2';
 import open from 'open';
 import path from 'node:path';
 
-interface ServerEvents {
+export interface ServerEvents {
   close: [];
   listen: [url: URL];
   wsmessage: [json: any];

--- a/src/staticFile.ts
+++ b/src/staticFile.ts
@@ -1,10 +1,10 @@
 import {AddClient, type FileInfo, MarkdownToHtml} from './html.js';
-import type {Http2ServerRequest, Http2ServerResponse, OutgoingHttpHeaders} from 'node:http2';
 import type {RequiredHostOptions} from './opts.js';
 import type {Stats} from 'node:fs';
 import type {WatchSet} from './watchSet.js';
 import {fileURLToPath} from 'node:url';
 import fs from 'node:fs/promises';
+import http2 from 'node:http2';
 import mt from 'mime-types';
 import path from 'node:path';
 
@@ -12,13 +12,22 @@ export interface ServerState {
   base: string;
   baseURL: URL;
   watcher: WatchSet;
-  headers: OutgoingHttpHeaders;
+  headers: http2.OutgoingHttpHeaders;
 }
 
 const FAVICON = 'favicon.ico';
 const S_FAVICON = `/${FAVICON}`;
 const assets = new URL('../assets/', import.meta.url);
 const F_FAVICON = fileURLToPath(new URL(FAVICON, assets));
+
+export const {
+  HTTP_STATUS_FORBIDDEN: FORBIDDEN,
+  HTTP_STATUS_INTERNAL_SERVER_ERROR: INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_METHOD_NOT_ALLOWED: METHOD_NOT_ALLOWED,
+  HTTP_STATUS_NOT_FOUND: NOT_FOUND,
+  HTTP_STATUS_NOT_MODIFIED: NOT_MODIFIED,
+  HTTP_STATUS_OK: OK,
+} = http2.constants;
 
 async function findExistingFile(
   dir: string,
@@ -54,17 +63,24 @@ async function findExistingFile(
 export async function staticFile(
   opts: RequiredHostOptions,
   state: ServerState,
-  req: Http2ServerRequest,
-  res: Http2ServerResponse
+  req: http2.Http2ServerRequest,
+  res: http2.Http2ServerResponse
 ): Promise<number> {
-  function error(code: number, text: string): number {
-    res.writeHead(code, state.headers).end(`${text}\n`);
+  function error(
+    code: number,
+    text: string,
+    headers?: http2.OutgoingHttpHeaders
+  ): number {
+    res.writeHead(code, {
+      ...state.headers,
+      ...headers,
+    }).end(`${text}\n`);
     return code;
   }
 
   try {
     if (req.method !== 'GET') {
-      return error(405, `Method ${req.method} not supported`);
+      return error(METHOD_NOT_ALLOWED, `Method ${req.method} not supported`);
     }
 
     const url = new URL(req.url, state.baseURL);
@@ -88,7 +104,7 @@ export async function staticFile(
       // Paths can be bad from the client, or bad because of symlinks.
       // Since this is a dev server, we're going to serve symlinks even if
       // they point outside the root directory.
-      return error(403, 'Invalid path');
+      return error(FORBIDDEN, 'Invalid path');
     } else {
       fh = await fs.open(file);
     }
@@ -103,11 +119,14 @@ export async function staticFile(
     // e.g. reconnect
     state.watcher.add(file);
 
-    // Same alg as nginx
-    const etag = `${stat.mtime.getTime().toString(16)}-${stat.size.toString(16)}`;
-    if (req.headers['if-none-match'] === etag) {
+    // Same alg as nginx.  MUST have dquotes.
+    const etag = `"${stat.mtime.getTime().toString(16)}-${stat.size.toString(16)}"`;
+    const inm = req.headers['if-none-match'];
+    // If prefaced with W/, that means "weak" algorithm ok.
+    // We're already pretty weak. :)
+    if (inm?.replace(/^W\/(?=")/, '') === etag) {
       fh.close();
-      return error(304, 'Not Modified');
+      return error(NOT_MODIFIED, 'Not Modified', {etag});
     }
 
     const info: FileInfo = {
@@ -126,22 +145,23 @@ export async function staticFile(
       info.stream = info.stream.pipe(new AddClient(info));
     }
 
-    const headers: OutgoingHttpHeaders = {
+    const headers: http2.OutgoingHttpHeaders = {
       ...state.headers,
-      'Content-Type': mime,
+      'content-type': mime,
+      'date': new Date(stat.mtime).toUTCString(),
       etag,
     };
     if (info.size) {
-      headers['Content-Length'] = info.size; // Otherwise chunked
+      headers['content-length'] = info.size; // Otherwise chunked
     }
-    res.writeHead(200, headers);
+    res.writeHead(OK, headers);
     info.stream.pipe(res);
-    return 200;
+    return OK;
   } catch (e) {
     const err = e as NodeJS.ErrnoException;
     if (err.code === 'ENOENT') {
-      return error(404, `No such file: "${req.url}"`);
+      return error(NOT_FOUND, `No such file: "${req.url}"`);
     }
-    return error(500, err.message);
+    return error(INTERNAL_SERVER_ERROR, err.message);
   }
 }

--- a/test/staticFile.test.js
+++ b/test/staticFile.test.js
@@ -63,5 +63,17 @@ test('staticFile', async() => {
   });
   code = await staticFile(opts, state, reqE, resE);
   assert.equal(code, 304);
+
+  const [reqO, resO] = reqRes('/', {
+    method: 'OPTIONS',
+  });
+  code = await staticFile(opts, state, reqO, resO);
+  assert.equal(code, 204);
+
+  const [reqH, resH] = reqRes('/favicon.ico', {
+    method: 'HEAD',
+  });
+  code = await staticFile(opts, state, reqH, resH);
+  assert.equal(code, 200);
 });
 


### PR DESCRIPTION
- **Make HTTP status codes come from constants.  Ensure etag is sent on 304 response.  Ignore 'W/' in if-none-match.**
- **Fixes #29.  Add OPTIONS and HEAD support.**
